### PR TITLE
Changed automatic scolling so that only the lyrics container scrolls

### DIFF
--- a/src/components/OneLine.jsx
+++ b/src/components/OneLine.jsx
@@ -1,6 +1,18 @@
 import React from "react";
 import { useState, useEffect, useRef } from "react";
 
+function getScrollParent(node) {
+  if (node == null) {
+    return null;
+  }
+
+  if (node.scrollHeight > node.clientHeight) {
+    return node;
+  } else {
+    return getScrollParent(node.parentNode);
+  }
+}
+
 const OneLine = ({ line, index, displayedLyricsIndex, goToLyricsPosition, isBigScreen, isDesktopOrLaptop, isTabletOrMobile}) => {
   const [lineActive, setLineActive] = useState(false);
   const lineRef = useRef()
@@ -12,7 +24,17 @@ const OneLine = ({ line, index, displayedLyricsIndex, goToLyricsPosition, isBigS
     }
     if (displayedLyricsIndex == index) {
       setLineActive(true);
-      lineRef.current.scrollIntoView({behavior:"smooth", block:"center", inline:"nearest"})
+      // implement "scrollIntoView" manually to ensure that only the lyrics container scrolls
+      const scrollableContainer = getScrollParent(lineRef.current);
+      if (scrollableContainer) {
+        const scrollPositionFactor = 0.3; // use 0.5 for vertical centering, but it makes sense to give a bit more space to the upcoming lines
+        const availableHeight = scrollableContainer.offsetHeight - lineRef.current.offsetHeight;
+        const scrollTarget = lineRef.current.offsetTop - scrollableContainer.offsetTop - availableHeight * scrollPositionFactor;
+        scrollableContainer.scrollTo({
+          top: scrollTarget,
+          behavior: "smooth",
+        });
+      }
       return;
     }
     setLineActive(false);


### PR DESCRIPTION
## What?
- Changed the scroll behaviour so that only the lyrics container is scrolled, no the whole body
- The active line is positioned at 1/3 of the container (instead of 1/2) so that more upcoming lines are displayed

## Why?
When playing a track, not only are the lyrics scrolled to match the current line, but with every line change, the whole body element is scrolled to the bottom to bring the complete lyrics section into view. On small screens and mobile, this makes it hard to adjust the mixer without pausing the playback first.

## How?
The native `scrollIntoView` function call is replaced by a call to `scrollTo` on the lyrics container element. This way, only the container is scrolled. The active line position can be adjusted with a `scrollPositionFactor` from 0.0 (top) to 1.0 (bottom).